### PR TITLE
added arm64 compatibility using TARGETPLATFORM

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -14,18 +14,27 @@ RUN rm -rf /var/lib/apt/lists/*
 
 # ---- Java Stage ----
 FROM base AS base_java
+ARG TARGETPLATFORM
 RUN apt-get update && apt-get install -y wget
-
-ARG JAVA_SOURCE="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz"
 ARG JAVA_FILE_NAME=java17.tar.gz
-RUN wget -O $JAVA_FILE_NAME $JAVA_SOURCE
-RUN tar -xzvf $JAVA_FILE_NAME -C /usr/local
-RUN rm $JAVA_FILE_NAME
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        JAVA_SOURCE="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz"; \
+    elif [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+        JAVA_SOURCE="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz"; \
+    else \
+        echo "Unsupported platform: $TARGETPLATFORM"; \
+        exit 1; \
+    fi && \
+    wget -O $JAVA_FILE_NAME $JAVA_SOURCE && \
+    tar -xzvf $JAVA_FILE_NAME -C /usr/local && \
+    rm $JAVA_FILE_NAME
+
 ENV JAVA_HOME=/usr/local/jdk-17.0.8.1+1
 ENV PATH=$JAVA_HOME/bin:$PATH
 
 # ---- Maven Stage ----
-FROM base_java as base_java_maven
+FROM base_java AS base_java_maven
 ARG MAVEN_SOURCE="https://dlcdn.apache.org/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.tar.gz"
 ARG MAVEN_FILE_NAME=maven.tar.gz
 RUN wget -O $MAVEN_FILE_NAME $MAVEN_SOURCE


### PR DESCRIPTION
I've set a conditional branch to switch between aarch64/x64 for the download of JDK,  so you can build also for arm64 platforms (EC2 Graviton, Mac M1/2/3/4, etc).

I've pushed on docker hub a arm64 image: https://hub.docker.com/r/yurik94/docx-to-pdf/tags